### PR TITLE
Fixed ablecore_mail module PHP warning

### DIFF
--- a/ablecore.module
+++ b/ablecore.module
@@ -222,7 +222,7 @@ function ablecore_theme_registry_alter(&$registry)
 		$filename = array_pop($segments);
 
 		// Get the module path.
-		$module_path = drupal_get_path('module', $module);
+        $module_path = dirname(drupal_get_filename('module', $module, NULL, FALSE));
 
 		// Prepare preprocessor paths.
 		$preprocess_filename = '/' . preg_quote($filename . '.php') . '/';

--- a/ablecore.module
+++ b/ablecore.module
@@ -221,9 +221,8 @@ function ablecore_theme_registry_alter(&$registry)
 		$segments = explode('/', $path);
 		$filename = array_pop($segments);
 
-
 		// Get the module path.
-        $module_path = dirname(drupal_get_filename('module', $module, NULL, FALSE));
+		$module_path = dirname(drupal_get_filename('module', $module, NULL, FALSE));
 
 		// Prepare preprocessor paths.
 		$preprocess_filename = '/' . preg_quote($filename . '.php') . '/';

--- a/ablecore.module
+++ b/ablecore.module
@@ -221,6 +221,7 @@ function ablecore_theme_registry_alter(&$registry)
 		$segments = explode('/', $path);
 		$filename = array_pop($segments);
 
+
 		// Get the module path.
         $module_path = dirname(drupal_get_filename('module', $module, NULL, FALSE));
 


### PR DESCRIPTION
Drupal core version 7.50 added an error parameter to the function `drupal_get_filename($type, $name, $filename = NULL, $trigger_error = TRUE)` so that it automatically gave a PHP warning when a file wasn't found.
